### PR TITLE
Fix/horizental low speed problem

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export type Config = {
   maxIdleThreads: number,
   /** 最大浏览时加载线程数 */
   threads: number,
+  maxPreloadDistance: number,
   /** 最大下载时加载线程数 */
   downloadThreads: number,
   /** 超时时间(秒)，默认16秒 */
@@ -154,6 +155,7 @@ export function defaultConf(): Config {
     restartIdleLoader: 2000,
     maxIdleThreads: 1,
     threads: 3,
+    maxPreloadDistance: 0,
     downloadThreads: 4,
     timeout: 10,
     version: CONF_VERSION,
@@ -366,6 +368,7 @@ export const transient = { imgSrcCSP: false, originalPolicy: "" };
 export type ConfigNumberType = "colCount"
   | "rowHeight"
   | "threads"
+  | "maxPreloadDistance"
   | "maxIdleThreads"
   | "downloadThreads"
   | "timeout"
@@ -426,6 +429,7 @@ export const ConfigItems: ConfigItem[] = [
   { key: "rowHeight", typ: "number" },
   { key: "maxIdleThreads", typ: "number" },
   { key: "threads", typ: "number" },
+  { key: "maxPreloadDistance", typ: "number" },
   { key: "downloadThreads", typ: "number" },
   { key: "paginationIMGCount", typ: "number" },
   { key: "timeout", typ: "number" },

--- a/src/fetcher-queue.ts
+++ b/src/fetcher-queue.ts
@@ -102,11 +102,12 @@ export class IMGFetcherQueue extends Array<IMGFetcher> {
     // Delay 300ms to avoid too many requests.  
     // If the user scrolls quickly through large images, it could otherwise trigger excessive requests.
     this.debouncer.addEvent("IFQ-EXECUTABLE", () => {
-      console.log("IFQ-EXECUTABLE: ", this.executableQueue);
-      Promise.all(this.executableQueue.splice(0, ADAPTER.conf.paginationIMGCount).map(imfIndex => this[imfIndex].start()))
+      const executableQueue = [...this.executableQueue];
+      console.log("IFQ-EXECUTABLE: ", executableQueue);
+      Promise.all(executableQueue.splice(0, ADAPTER.conf.paginationIMGCount).map(imfIndex => this[imfIndex].start()))
         .then(() => {
           const picked = this.cherryPick?.(this.chapterIndex);
-          this.executableQueue.filter(i => !picked || picked.picked(i)).forEach(imfIndex => this[imfIndex].start());
+          executableQueue.filter(i => !picked || picked.picked(i)).forEach(imfIndex => this[imfIndex].start());
         });
     }, 300);
   }
@@ -161,6 +162,7 @@ export class IMGFetcherQueue extends Array<IMGFetcher> {
     if (!ret) return false;
     const threads = ADAPTER.conf.threads + ADAPTER.conf.paginationIMGCount - 1;
     const distance = Math.abs(index - this.currIndex);
+    if (ADAPTER.conf.maxPreloadDistance > 0 && distance > ADAPTER.conf.maxPreloadDistance) return false;
     if (threads >= distance || (ADAPTER.conf.threads > 0 && count < threads)) return true;
     return false;
   }

--- a/src/platform/matchers/pinterest.ts
+++ b/src/platform/matchers/pinterest.ts
@@ -41,7 +41,7 @@ type PinterestPage = {
 }
 
 const RESOURCE_NAME = "BaseSearchResource";
-const PIN_ID_REGEXP = /\/pin\/(\d+)/;
+const PIN_ID_REGEXP = /\/pin\/([^/]+)/;
 const PIN_IMG_SELECTOR = "a[href*='/pin/'] img[src*='pinimg.com']";
 const DOM_PIN_BATCH_SIZE = 16;
 
@@ -50,6 +50,7 @@ type PinterestDomPin = {
   href: string,
   title: string,
   thumbnailSrc: string,
+  originSrc?: string,
   rect: {
     w: number,
     h: number,
@@ -71,26 +72,44 @@ class PinterestMatcher extends BaseMatcher<PinterestPage> {
         return;
       }
 
-      const initial = parseInitialProps();
       if (isPinPage()) {
-        const pins = extractPinPagePins(initial);
-        pins.forEach(pin => this.seenPinIDs.add(pin.id));
-        yield Result.ok({ pins });
+        const initial = tryParseInitialProps();
+        if (initial) {
+          const pins = extractPinPagePins(initial);
+          pins.forEach(pin => this.seenPinIDs.add(pin.id));
+          yield Result.ok({ pins });
+        }
         for await (const page of this.fetchDomPinPages()) {
           yield Result.ok(page);
         }
         return;
       }
 
-      const resource = extractSearchResource(initial);
+      const initial = tryParseInitialProps();
+      const resource = initial ? tryExtractSearchResource(initial) : undefined;
+      if (!resource) {
+        for await (const page of this.fetchDomPinPages()) {
+          yield Result.ok(page);
+        }
+        return;
+      }
       this.resourceOptions = resource.options;
       this.nextBookmark = resource.nextBookmark;
+      resource.pins.forEach(pin => this.seenPinIDs.add(pin.id));
       yield Result.ok({ pins: resource.pins, nextBookmark: resource.nextBookmark });
 
       while (this.nextBookmark && this.nextBookmark !== "-end-") {
-        const next = await this.fetchSearchPage(this.nextBookmark);
-        this.nextBookmark = next.nextBookmark;
-        yield Result.ok(next);
+        try {
+          const next = await this.fetchSearchPage(this.nextBookmark);
+          this.nextBookmark = next.nextBookmark;
+          next.pins?.forEach(pin => this.seenPinIDs.add(pin.id));
+          yield Result.ok(next);
+        } catch {
+          this.nextBookmark = undefined;
+          for await (const page of this.fetchDomPinPages()) {
+            yield Result.ok(page);
+          }
+        }
       }
     } catch (error) {
       yield Result.err(error as Error);
@@ -121,7 +140,7 @@ class PinterestMatcher extends BaseMatcher<PinterestPage> {
         pin.href,
         buildTitleFromText(pin.title, pin.id, pin.thumbnailSrc),
         undefined,
-        undefined,
+        pin.originSrc,
         pin.rect,
       ));
       this.pinCount++;
@@ -201,14 +220,15 @@ class PinterestMatcher extends BaseMatcher<PinterestPage> {
     for (const img of imgs) {
       const href = img.closest<HTMLAnchorElement>("a[href*='/pin/']")?.href;
       const id = href?.match(PIN_ID_REGEXP)?.[1];
-      const src = img.currentSrc || img.src;
-      if (!href || !id || !src || id === currentID || this.seenPinIDs.has(id)) continue;
+      const srcs = pickDomImageSrcs(img);
+      if (!href || !id || !srcs.thumbnail || id === currentID || this.seenPinIDs.has(id)) continue;
       this.seenPinIDs.add(id);
       pins.push({
         id,
         href,
         title: img.alt || `pinterest-${id}`,
-        thumbnailSrc: src,
+        thumbnailSrc: srcs.thumbnail,
+        originSrc: srcs.origin,
         rect: {
           w: img.naturalWidth || img.width || 236,
           h: img.naturalHeight || img.height || 236,
@@ -237,6 +257,14 @@ function parseInitialProps(doc: Document = document): PinterestInitialProps {
   return JSON.parse(raw) as PinterestInitialProps;
 }
 
+function tryParseInitialProps(doc: Document = document): PinterestInitialProps | undefined {
+  try {
+    return parseInitialProps(doc);
+  } catch {
+    return undefined;
+  }
+}
+
 function extractSearchResource(initial: PinterestInitialProps): { options: Record<string, unknown>, pins: PinterestPin[], nextBookmark?: string } {
   const resources = initial.initialReduxState?.resources?.[RESOURCE_NAME];
   const entry = resources ? Object.entries(resources)[0] : undefined;
@@ -245,6 +273,14 @@ function extractSearchResource(initial: PinterestInitialProps): { options: Recor
   const options = Object.fromEntries(JSON.parse(optionsRaw) as [string, unknown][]);
   const pins = Array.isArray(resource.data?.results) ? resource.data.results.filter(isPin) : [];
   return { options, pins, nextBookmark: resource.nextBookmark };
+}
+
+function tryExtractSearchResource(initial: PinterestInitialProps): { options: Record<string, unknown>, pins: PinterestPin[], nextBookmark?: string } | undefined {
+  try {
+    return extractSearchResource(initial);
+  } catch {
+    return undefined;
+  }
 }
 
 function extractPinPagePins(initial: PinterestInitialProps, expectedID?: string): PinterestPin[] {
@@ -271,6 +307,18 @@ function pickImage(images: PinterestImageMap, keys: string[]): PinterestImage | 
     }
   }
   return Object.values(images).flat().find(img => img?.url);
+}
+
+function pickDomImageSrcs(img: HTMLImageElement): { thumbnail: string, origin?: string } {
+  const srcset = (img.getAttribute("srcset") ?? "")
+    .split(",")
+    .map(src => src.trim().split(/\s+/)[0])
+    .filter(Boolean);
+  const current = img.currentSrc || img.src;
+  const sources = [...srcset, current].filter(Boolean);
+  const origin = sources.find(src => src.includes("/originals/")) ?? sources.find(src => src.includes("/736x/")) ?? current;
+  const thumbnail = current || sources.find(src => src.includes("/474x/")) || sources.find(src => src.includes("/236x/")) || origin;
+  return { thumbnail, origin };
 }
 
 function buildTitle(pin: PinterestPin, src: string): string {

--- a/src/ui/big-image-frame-manager.ts
+++ b/src/ui/big-image-frame-manager.ts
@@ -16,6 +16,12 @@ import { HTMLUgoiraElement } from "../utils/ugoira";
 import { SubData } from "../platform/platform";
 
 type MediaElement = HTMLImageElement | HTMLVideoElement | HTMLUgoiraElement;
+type ViewportAxis = "x" | "y";
+type ViewportPosition = {
+  center: number,
+  end: number,
+  start: number,
+};
 
 export class BigImageFrameManager {
   root: HTMLElement;
@@ -40,6 +46,7 @@ export class BigImageFrameManager {
   lastMouse?: { x: number, y: number };
   pageNumInChapter: number[] = [];
   oriented: Oriented = "next";
+  lastViewportSyncAt: number = 0;
   // When bifm opens an image, the IntersectionObserver will immediately start detecting and rendering after 50 milliseconds, 
   // but we want to only start rendering when the corresponding image index is detected.
   intersectingIndexLock: boolean = false;
@@ -51,6 +58,8 @@ export class BigImageFrameManager {
     this.getChapter = getChapter;
     this.scrollerY = new Scroller(this.root);
     this.scrollerX = new Scroller(this.root, undefined, "x");
+    this.scrollerY.onScrolled = () => this.syncCurrentFromViewportThrottled();
+    this.scrollerX.onScrolled = () => this.syncCurrentFromViewportThrottled();
 
     this.container = document.createElement("div");
     this.container.classList.add("bifm-container");
@@ -330,8 +339,8 @@ export class BigImageFrameManager {
   }
 
   scrollStop() {
-    this.scrollerY.scrolling = false;
-    this.scrollerX.scrolling = false;
+    this.scrollerY.stop();
+    this.scrollerX.stop();
   }
 
   hidden(event?: MouseEvent) {
@@ -451,6 +460,7 @@ export class BigImageFrameManager {
         } else {
           this.root.scrollLeft = element.offsetLeft;
         }
+        this.syncCurrentFromViewport();
         break;
       }
       case "continuous": {
@@ -461,6 +471,7 @@ export class BigImageFrameManager {
         let marginT = index === 0 ? 0 : Math.floor((rootH - height) / 2);
         marginT = Math.max(0, marginT);
         this.root.scrollTop = element.offsetTop - marginT;
+        this.syncCurrentFromViewport();
         break;
       }
     }
@@ -488,6 +499,8 @@ export class BigImageFrameManager {
   }
 
   checkCurrent() {
+    if (this.syncCurrentFromViewport()) return;
+
     const rootRect = this.root.getBoundingClientRect();
     const isCenter: (rect: DOMRect, rootRect: DOMRect) => boolean = (() => {
       if (ADAPTER.conf.readMode === "continuous") {
@@ -502,15 +515,73 @@ export class BigImageFrameManager {
       if (isCenter(rect, rootRect)) {
         const imf = this.getIMF(element);
         if (imf === null) continue;
-        if (imf.index === this.currentIndex) continue;
-        EBUS.emit("ifq-do", imf.index, imf, this.oriented);
-        this.currentIndex = imf.index;
-        this.pageNumInChapter[this.chapterIndex] = imf.index;
-        if (element.firstElementChild) {
-          this.tryPlayVideo(element.firstElementChild as HTMLElement);
-        }
+        this.setCurrentFromElement(element, imf);
         break;
       }
+    }
+  }
+
+  syncCurrentFromViewport(): boolean {
+    if (ADAPTER.conf.readMode === "pagination") return false;
+    const rootRect = this.root.getBoundingClientRect();
+    const axis = this.viewportAxis();
+    const root = viewportPosition(rootRect, axis);
+    let nearest: { element: HTMLElement, distance: number } | undefined;
+
+    for (const element of Array.from(this.container.children) as HTMLElement[]) {
+      const index = parseIndex(element);
+      if (index < 0) continue;
+      const rect = element.getBoundingClientRect();
+      const elementPos = viewportPosition(rect, axis);
+      if (!isVisibleInViewport(root, elementPos)) continue;
+      if (this.trySetCenteredElement(element, elementPos, root.center)) return true;
+      nearest = nearestViewportElement(nearest, element, elementPos, root.center);
+    }
+
+    return this.trySetNearestElement(nearest);
+  }
+
+  syncCurrentFromViewportThrottled(timeout: number = 80) {
+    const now = Date.now();
+    if (now - this.lastViewportSyncAt < timeout) return;
+    this.lastViewportSyncAt = now;
+    this.syncCurrentFromViewport();
+  }
+
+  private trySetCenteredElement(element: HTMLElement, position: ViewportPosition, center: number): boolean {
+    if (position.start > center || position.end < center) return false;
+    const imf = this.getIMF(element);
+    if (imf === null) return false;
+    this.setCurrentFromElement(element, imf);
+    return true;
+  }
+
+  private trySetNearestElement(nearest?: { element: HTMLElement }): boolean {
+    if (!nearest) return false;
+    const imf = this.getIMF(nearest.element);
+    if (imf === null) return false;
+    this.setCurrentFromElement(nearest.element, imf);
+    return true;
+  }
+
+  private viewportAxis(): ViewportAxis {
+    return ADAPTER.conf.readMode === "horizontal" ? "x" : "y";
+  }
+
+  private setCurrentFromElement(element: HTMLElement, imf: IMGFetcher) {
+    if (!this.renderingElements.includes(element)) {
+      this.renderingElements.push(element);
+    }
+    if (element.childElementCount === 0) {
+      element.appendChild(this.newMediaNode(imf));
+    }
+    if (imf.index !== this.currentIndex) {
+      this.currentIndex = imf.index;
+      this.pageNumInChapter[this.chapterIndex] = imf.index;
+      EBUS.emit("ifq-do", imf.index, imf, this.oriented);
+    }
+    if (element.firstElementChild) {
+      this.tryPlayVideo(element.firstElementChild as HTMLElement);
     }
   }
 
@@ -566,11 +637,12 @@ export class BigImageFrameManager {
       }
     }
     if (ADAPTER.conf.readMode !== "pagination") {
+      this.syncCurrentFromViewportThrottled();
       this.debouncer.addEvent("bifm-on-wheel", () => this.checkCurrent(), 69);
     }
   }
 
-  onWheel(event: WheelEvent, noPrevent?: boolean, customScrolling?: boolean, noCallback?: boolean, originEvent?: Event) {
+  onWheel(event: WheelEvent, noPrevent?: boolean, customScrolling?: boolean, noCallback?: boolean, originEvent?: Event): Promise<void> {
     const preventDefault = () => {
       event.preventDefault();
       originEvent?.preventDefault();
@@ -579,60 +651,100 @@ export class BigImageFrameManager {
     if (event.buttons === 2) {
       preventDefault();
       this.scaleBigImages(event.deltaY > 0 ? -1 : 1, 5);
-      return;
+      return Promise.resolve();
     }
     const withShift = originEvent instanceof WheelEvent && originEvent.shiftKey;
     const smartScrolling = !withShift && ADAPTER.conf.smartScrolling;
     switch (ADAPTER.conf.readMode) {
-      case "pagination": {
-        const over = this.checkOverflow();
-
-        let deltaY = event.deltaY;
-        if (withShift && ADAPTER.conf.reversePages) deltaY = deltaY * -1;
-        const [o, neg_o]: [Oriented, Oriented] = deltaY > 0 ? ["next", "prev"] : ["prev", "next"];
-        this.oriented = o;
-        const [$ori, $neg] = ADAPTER.conf.reversePages ? [neg_o, o] : [o, neg_o];
-
-        const rotated = this.root.classList.contains("bifm-rotate-90") || this.root.classList.contains("bifm-rotate-270");
-        if (rotated) {
-          this.stepNext(this.oriented);
-          break;
-        }
-
-        if (over[o].overY - 1 <= 0 && over[$ori].overX - 1 <= 0) { // reached boundary, step next
-          preventDefault();
-          if (!noPrevent) {
-            if (over[neg_o].overY > 0 || over[$neg].overX > 0) {
-              if (this.tryPreventStep()) break;
-            }
-          }
-          this.stepNext(o);
-          break;
-        }
-        let fix = o === "next" ? 1 : -1;
-        if (customScrolling && over[o].overY > 0) {
-          this.scrollerY.scroll(Math.min(over[o].overY, Math.abs(event.deltaY * 3)) * fix, Math.abs(Math.ceil(event.deltaY / 4)));
-        }
-        if (customScrolling || smartScrolling) {
-          fix = fix * (ADAPTER.conf.reversePages ? -1 : 1);
-          if (over[o].overY - 1 <= 0 && over[$ori].overX > 0) { // should scroll
-            this.scrollerX.scroll(Math.min(over[$ori].overX, Math.abs(event.deltaY * 3)) * fix, Math.abs(Math.ceil(event.deltaY / 4)));
-          }
-        }
+      case "pagination":
+        this.handlePaginationWheel(event, withShift, smartScrolling, customScrolling, noPrevent, preventDefault);
         break;
-      }
-      case "horizontal": {
-        if (customScrolling || smartScrolling) {
-          preventDefault();
-          this.scrollerX.scroll(event.deltaY * (ADAPTER.conf.reversePages ? -1 : 1), ADAPTER.conf.scrollingSpeed);
-        }
-        break;
-      }
-      case "continuous": {
-        if (customScrolling) {
-          this.scrollerY.scroll(event.deltaY, ADAPTER.conf.scrollingSpeed);
-        }
-        break;
+      case "horizontal":
+        return this.handleHorizontalWheel(event, smartScrolling, customScrolling, preventDefault);
+      case "continuous":
+        return this.handleContinuousWheel(event, customScrolling);
+    }
+    return Promise.resolve();
+  }
+
+  private handlePaginationWheel(
+    event: WheelEvent,
+    withShift: boolean,
+    smartScrolling: boolean,
+    customScrolling: boolean | undefined,
+    noPrevent: boolean | undefined,
+    preventDefault: () => void,
+  ) {
+    const over = this.checkOverflow();
+    const direction = wheelDirection(event.deltaY, withShift);
+    this.oriented = direction.o;
+    const [$ori, $neg] = ADAPTER.conf.reversePages ? [direction.neg, direction.o] : [direction.o, direction.neg];
+
+    if (this.isRotated()) {
+      this.stepNext(this.oriented);
+      return;
+    }
+    if (this.tryStepAtPaginationBoundary(over, direction.o, direction.neg, $ori, $neg, noPrevent, preventDefault)) return;
+    this.scrollInsidePagination(event, over, direction.o, $ori, customScrolling, smartScrolling);
+  }
+
+  private handleHorizontalWheel(
+    event: WheelEvent,
+    smartScrolling: boolean,
+    customScrolling: boolean | undefined,
+    preventDefault: () => void,
+  ): Promise<void> {
+    if (!customScrolling && !smartScrolling) return Promise.resolve();
+    preventDefault();
+    return this.scrollerX
+      .scroll(event.deltaY * (ADAPTER.conf.reversePages ? -1 : 1), ADAPTER.conf.scrollingSpeed)
+      .then(() => { this.syncCurrentFromViewport(); });
+  }
+
+  private handleContinuousWheel(event: WheelEvent, customScrolling?: boolean): Promise<void> {
+    if (!customScrolling) return Promise.resolve();
+    return this.scrollerY
+      .scroll(event.deltaY, ADAPTER.conf.scrollingSpeed)
+      .then(() => { this.syncCurrentFromViewport(); });
+  }
+
+  private isRotated(): boolean {
+    return this.root.classList.contains("bifm-rotate-90") || this.root.classList.contains("bifm-rotate-270");
+  }
+
+  private tryStepAtPaginationBoundary(
+    over: { "prev": { overX: number, overY: number }, "next": { overX: number, overY: number } },
+    o: Oriented,
+    neg: Oriented,
+    $ori: Oriented,
+    $neg: Oriented,
+    noPrevent: boolean | undefined,
+    preventDefault: () => void,
+  ): boolean {
+    if (over[o].overY - 1 > 0 || over[$ori].overX - 1 > 0) return false;
+    preventDefault();
+    if (!noPrevent && (over[neg].overY > 0 || over[$neg].overX > 0) && this.tryPreventStep()) return true;
+    this.stepNext(o);
+    return true;
+  }
+
+  private scrollInsidePagination(
+    event: WheelEvent,
+    over: { "prev": { overX: number, overY: number }, "next": { overX: number, overY: number } },
+    o: Oriented,
+    $ori: Oriented,
+    customScrolling: boolean | undefined,
+    smartScrolling: boolean,
+  ) {
+    let fix = o === "next" ? 1 : -1;
+    const step = Math.abs(Math.ceil(event.deltaY / 4));
+    if (customScrolling && over[o].overY > 0) {
+      this.scrollerY.scroll(Math.min(over[o].overY, Math.abs(event.deltaY * 3)) * fix, step);
+    }
+    if (customScrolling || smartScrolling) {
+      fix = fix * (ADAPTER.conf.reversePages ? -1 : 1);
+      if (over[o].overY - 1 <= 0 && over[$ori].overX > 0) {
+        this.scrollerX.scroll(Math.min(over[$ori].overX, Math.abs(event.deltaY * 3)) * fix, step);
       }
     }
   }
@@ -998,6 +1110,43 @@ function parseIndex(ele: HTMLElement): number {
   const d = ele.getAttribute("d-index") || "";
   const i = parseInt(d);
   return isNaN(i) ? -1 : i;
+}
+
+function isVisibleInViewport(root: ViewportPosition, element: ViewportPosition): boolean {
+  return element.end >= root.start && element.start <= root.end;
+}
+
+function nearestViewportElement(
+  nearest: { element: HTMLElement, distance: number } | undefined,
+  element: HTMLElement,
+  position: ViewportPosition,
+  center: number,
+): { element: HTMLElement, distance: number } {
+  const elementCenter = position.start + (position.end - position.start) / 2;
+  const distance = Math.abs(elementCenter - center);
+  if (!nearest || distance < nearest.distance) return { element, distance };
+  return nearest;
+}
+
+function viewportPosition(rect: DOMRect, axis: ViewportAxis): ViewportPosition {
+  if (axis === "x") {
+    return {
+      center: rect.left + rect.width / 2,
+      end: rect.right,
+      start: rect.left,
+    };
+  }
+  return {
+    center: rect.top + rect.height / 2,
+    end: rect.bottom,
+    start: rect.top,
+  };
+}
+
+function wheelDirection(deltaY: number, withShift: boolean): { o: Oriented, neg: Oriented } {
+  if (withShift && ADAPTER.conf.reversePages) deltaY = deltaY * -1;
+  const [o, neg]: [Oriented, Oriented] = deltaY > 0 ? ["next", "prev"] : ["prev", "next"];
+  return { o, neg };
 }
 
 function stickyMouse(element: HTMLElement, event: MouseEvent, lastMouse: { x: number, y: number }, elementsWidth?: number) {

--- a/src/ui/event.ts
+++ b/src/ui/event.ts
@@ -84,6 +84,7 @@ export function initEvents(HTML: Elements, BIFM: BigImageFrameManager, FVGM: Ful
         colCount: [1, 12],
         rowHeight: [50, 4096],
         threads: [0, 10],
+        maxPreloadDistance: [0, 200],
         maxIdleThreads: [0, 10],
         downloadThreads: [1, 10],
         timeout: [2, 40],

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -102,6 +102,18 @@ const i18nData = {
     '큰 이미지 모드에서 다음 이미지로 이동할 때 미리 로드할 이미지 수입니다.<br>이 값이 1보다 클 경우, 동시에 로드되는 이미지가 더 많아져서 사용 경험이 향상됩니다.',
     'Hilos máximos de pre-carga'
   ],
+  maxPreloadDistance: [
+    'Max Preload Distance',
+    '最大预加载距离',
+    'Max Preload Distance',
+    'Distancia maxima de precarga'
+  ],
+  maxPreloadDistanceTooltip: [
+    'Do not preload images farther than this many pages from the current image. Set to 0 to disable the distance limit.',
+    '不预加载距离当前图片超过此页数的图片。设为 0 可关闭距离限制。',
+    'Do not preload images farther than this many pages from the current image. Set to 0 to disable the distance limit.',
+    'No precargar imagenes mas lejos que esta distancia desde la imagen actual. Use 0 para desactivar el limite.'
+  ],
   maxIdleThreads: [
     'Idle Threads',
     '最大空闲时加载',

--- a/src/utils/scroller.ts
+++ b/src/utils/scroller.ts
@@ -5,10 +5,14 @@ export class Scroller {
   private distance: number = 0;
   private additional: number = 0;
   private lastDirection: "up" | "down" | undefined;
-  private directionChanged: boolean = false;
+  private animationID: number = 0;
+  private scrollSign: 1 | -1 = 1;
+  private currentPromise?: Promise<void>;
+  private currentResolve?: () => void;
   private scrollMargin: () => number;
   private maxScrollMargin: () => number;
   private setScrollMargin: (margin: number) => void;
+  onScrolled?: () => void;
   constructor(element: HTMLElement, step?: number, mode?: "y" | "x") {
     this.element = element;
     this.step = step || 1;
@@ -25,39 +29,55 @@ export class Scroller {
 
   scroll(delta: number, step?: number): Promise<void> {
     if (step) this.step = step;
-    let resolve: () => void;
-    const promise = new Promise<void>((r) => resolve = r);
-    this.distance = Math.abs(delta);
+    const distance = Math.abs(delta);
+    if (distance <= 0) return Promise.resolve();
     const direction = delta < 0 ? "up" : "down";
-    this.directionChanged = this.lastDirection !== undefined && this.lastDirection !== direction;
-    if (this.scrolling || this.distance <= 0) {
-      // this.additional = 0; // disable additional temporary
-      return promise;
+    if (this.scrolling) {
+      if (this.lastDirection === direction) {
+        this.distance += distance;
+        return this.currentPromise ?? Promise.resolve();
+      }
+      this.finishScroll();
     }
-    const sign = delta / this.distance;
+
+    const promise = new Promise<void>((resolve) => this.currentResolve = resolve);
+    this.currentPromise = promise;
+    this.distance = distance;
+    this.scrollSign = delta < 0 ? -1 : 1;
     this.lastDirection = direction;
     this.additional = 0;
     this.scrolling = true;
-    const scrolled = () => {
-      this.scrolling = false;
-      this.directionChanged = false;
-      this.lastDirection = undefined;
-      this.distance = 0;
-      resolve?.();
-    };
-    // console.log(`scroller: delta: ${delta}, step: ${step}, distance: ${this.distance}, scrolling: ${this.scrolling}, direction: ${direction}, changed: ${this.directionChanged}`);
+    const animationID = ++this.animationID;
+    // console.log(`scroller: delta: ${delta}, step: ${step}, distance: ${this.distance}, scrolling: ${this.scrolling}, direction: ${direction}`);
     const doFrame = () => {
-      if (!this.scrolling) return scrolled();
+      if (animationID !== this.animationID) return;
+      if (!this.scrolling) return this.finishScroll();
       this.distance -= this.step + this.additional;
-      let scrollMargin = this.scrollMargin() + ((this.step + this.additional) * sign);
+      let scrollMargin = this.scrollMargin() + ((this.step + this.additional) * this.scrollSign);
       scrollMargin = Math.max(scrollMargin, 0);
       scrollMargin = Math.min(scrollMargin, this.maxScrollMargin());
       this.setScrollMargin(scrollMargin);
-      if (this.distance <= 0 || this.directionChanged || scrollMargin === 0 || scrollMargin === this.maxScrollMargin()) return scrolled();
+      this.onScrolled?.();
+      if (this.distance <= 0 || scrollMargin === 0 || scrollMargin === this.maxScrollMargin()) return this.finishScroll();
       window.requestAnimationFrame(doFrame);
     }
     window.requestAnimationFrame(doFrame);
     return promise;
+  }
+
+  stop() {
+    this.finishScroll();
+  }
+
+  private finishScroll() {
+    this.animationID++;
+    this.scrolling = false;
+    this.lastDirection = undefined;
+    this.distance = 0;
+    const resolve = this.currentResolve;
+    this.currentPromise = undefined;
+    this.currentResolve = undefined;
+    resolve?.();
   }
 }
 


### PR DESCRIPTION
Changelog
Add/fix Pinterest support
Improved fallback behavior when Pinterest search resource loading fails.
Falls back to collecting Pin images from the page DOM when the search resource API is unavailable.
Improved Pin deduplication and batched collection for better Pinterest search/detail page support.

Fix horizontal low-speed scrolling sync
Fixed stale page number updates in horizontal mode when auto-scrolling with low scrollingSpeed.
Syncs the current page from the viewport center while scrolling, ensuring ifq-do fires and nearby full-size images load.
Fixed Scroller re-entry behavior so continuous low-speed scrolling can append distance without losing scroll progress.
Fixed async shared preload queue state to prevent fast scrolling from loading images outside the intended range.
Added Max Preload Distance, default 0, to limit browsing preload distance; set to 0 to disable the limit.